### PR TITLE
Fix: Make scaffolded demo code pass ruff (I, UP, G)

### DIFF
--- a/{{cookiecutter.repository_folder_name}}/pyproject.toml
+++ b/{{cookiecutter.repository_folder_name}}/pyproject.toml
@@ -8,7 +8,6 @@ dependencies = [
     "keboola-component>=1.9.0",
     "keboola-http-client>=1.0.1",
     "keboola-utils>=1.1.0",
-    "mock>=5.2.0",
     "pydantic>=2.11.7",
 ]
 

--- a/{{cookiecutter.repository_folder_name}}/src/component.py
+++ b/{{cookiecutter.repository_folder_name}}/src/component.py
@@ -43,7 +43,7 @@ class Component(ComponentBase):
         # get input table definitions
         input_tables = self.get_input_tables_definitions()
         for table in input_tables:
-            logging.info(f"Received input table: {table.name} with path: {table.full_path}")
+            logging.info("Received input table: %s with path: %s", table.name, table.full_path)
 
         if len(input_tables) == 0:
             raise UserException("No input tables found")
@@ -62,8 +62,8 @@ class Component(ComponentBase):
         # Add timestamp column and save into out_table_path
         input_table = input_tables[0]
         with (
-            open(input_table.full_path, "r") as inp_file,
-            open(table.full_path, mode="wt", encoding="utf-8", newline="") as out_file,
+            open(input_table.full_path) as inp_file,
+            open(table.full_path, mode="w", encoding="utf-8", newline="") as out_file,
         ):
             reader = csv.DictReader(inp_file)
 

--- a/{{cookiecutter.repository_folder_name}}/tests/__init__.py
+++ b/{{cookiecutter.repository_folder_name}}/tests/__init__.py
@@ -1,4 +1,4 @@
 import sys
 from pathlib import Path
 
-sys.path.append(str((Path(__file__).resolve().parent.parent / "src")))
+sys.path.append(str(Path(__file__).resolve().parent.parent / "src"))

--- a/{{cookiecutter.repository_folder_name}}/tests/test_component.py
+++ b/{{cookiecutter.repository_folder_name}}/tests/test_component.py
@@ -1,7 +1,7 @@
 import os
 import unittest
+from unittest import mock
 
-import mock
 from freezegun import freeze_time
 
 from component import Component


### PR DESCRIPTION
## Problem

After #20 made the initial commit buildable, freshly generated components still failed CI at the **Build Test Image** step:

```
process "/bin/sh -c uv run ruff check src/ tests/" did not complete successfully: exit code: 1
```

The test stage runs `uv run ruff check src/ tests/`, but the scaffolded demo code did not pass the template's own ruff config (`extend-select = ["I", "UP", "G"]`). So the initial commit still could not be released.

## Fix

- **G004**: `logging.info` f-string → lazy %-style formatting
- **UP015**: `open(path, "r")` → `open(path)`; `mode="wt"` → `mode="w"`
- **UP034**: drop extraneous parentheses in `tests/__init__.py`
- **UP026**: `import mock` → `from unittest import mock`, and drop the now-unused `mock` dependency

The generated component's `uv.lock` is created fresh by the post-gen hook (`uv lock`), so no committed lockfile needs updating in the template.

## Verification

Generated a component from the template and confirmed:
- `uv run ruff check src/ tests/` passes
- `docker build --target test` and `--target production` both succeed
- the unit test passes inside the test image

Validated live on two real components generated from the template (keboola/component-wr-abra-flexi#2, keboola/component-ex-premier#2) — the same fix turned their pipelines green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)