### PR TITLE
ship uiOptions.md default so new components render a UI

### DIFF
--- a/TEMPLATE_README.md
+++ b/TEMPLATE_README.md
@@ -107,6 +107,9 @@ Currently these Dev Portal configuration parameters are supported:
  - `configRowSchema.json`
  - `component_short_description.md`
  - `component_long_description.md`
+ - `uiOptions.md`
+
+`uiOptions.md` controls which configuration UI the platform renders. It ships with `["genericDockerUI"]` so the standard config form shows up on first deploy. For a row-based component add `"genericDockerUI-rows"`, and for an OAuth component add `"genericDockerUI-authorization"`.
 
 The choice to include this script directly in the main branch was made to simplify ad-hoc changes of the component configuration parameters. For instance, if you wish to slightly modify the configuration schema without affecting the code itself, it is possible to simply push the changes directly into the master and these will be automatically propagated to the production without rebuilding the image itself. Solely Developer Portal configuration metadata is deployed at this stage.
 

--- a/{{cookiecutter.repository_folder_name}}/component_config/uiOptions.md
+++ b/{{cookiecutter.repository_folder_name}}/component_config/uiOptions.md
@@ -1,0 +1,1 @@
+["genericDockerUI"]


### PR DESCRIPTION
## Problem
`scripts/developer_portal/update_properties.sh` (line 56) pushes
`component_config/uiOptions.md`, but the template never shipped that file.
`update_property` hits its "file not found, skipping" branch, so a fresh
component reaches the Developer Portal with `uiOptions: []` → `hasUI: false`
→ no configuration UI, even after a successful release. Every new component
hits this and fixes it by hand.

## Change
- Ship `component_config/uiOptions.md` = `["genericDockerUI"]` (the minimum
  that renders the standard config form; the existing script pushes it on deploy).
- Document it in `TEMPLATE_README.md`, noting `genericDockerUI-rows` for
  row-based components and `genericDockerUI-authorization` for OAuth.

## Notes
`["genericDockerUI"]` is the safe default — the template doesn't know whether a
component is row-based. Row/OAuth flags stay a one-line edit by the developer.